### PR TITLE
Fix: Frontend Server Port 변경

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -63,6 +63,7 @@ module.exports = {
   devServer: {
     static: { directory: path.resolve(__dirname, "dist") },
     hot: true,
+    port: 3000,
     historyApiFallback: true,
   },
 };


### PR DESCRIPTION
## What is this PR? 🔍
backend server의 포트가 `8080` 이여서 프런트 서버 포트를 `3000`으로 변경