### PR TITLE
fix: Github Actions `Build` Directory Setting

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    env:
+      working-directory: ./frontend
     steps:
       - uses: actions/checkout@v2
       - run: npm run build


### PR DESCRIPTION
## What is this PR? 🔍
github action이 `build` 하는 디렉토리를 지정해줘야한다.