### PR TITLE
fix: `.env`파일이 생성되는 경로 추가

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,10 +11,10 @@ jobs:
         working-directory: frontend
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: Generate Environment Variables File for Production
-        run: echo "export const DASONI_BACKEND_API=$DASONI_BACKEND_API" >> .env.production
-        env: 
+        run: echo "export const DASONI_BACKEND_API=$DASONI_BACKEND_API" >> ./src/.env/index.ts
+        env:
           DASONI_BACKEND_API: ${{ secrets.DASONI_BACKEND_API }}
 
       - name: Install Dependencies


### PR DESCRIPTION
## What is this PR? 🔍
```bash
Module not found: Error: Can't resolve '../../.env'
```
`.env` 파일이 `root`에 생겨서 환경변수를 찾지 못해 에러가 생겼다.
`.env` 파일이 생기는 위치를 설정해줬다.