### PR TITLE
fix: 환경변수를 넣어둔 파일을

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Generate Environment Variables File for Production
-        run: echo "export const DASONI_BACKEND_API=DASONI_BACKEND_API" >> src/secret/index.ts
+        run: mkdir -p src/secret && echo "export const DASONI_BACKEND_API=$DASONI_BACKEND_API" >> src/secret/index.ts
         env:
           DASONI_BACKEND_API: ${{ secrets.DASONI_BACKEND_API }}
 


### PR DESCRIPTION
## What is this PR? 🔍

#25 에러가 해결되지 않았다.

### Solve

#25 에서 폴더구조를 적용해서 파일을 생성해줬지만 정작 해당 폴더가 생기지 않았다.
`echo` 뒤에 절대경로를 적으면 파일과 함께 폴더도 같이 생길 줄 알았는데, 폴더를 생성하는 명령어를 함께 적어줘야 해당 폴더가 생긴다음에 -> 해당 위치에 파일이 생긴다.
```
mkdir -p src/secret && echo "export const DASONI_BACKEND_API=$DASONI_BACKEND_API" >> src/secret/index.ts
```
리눅스 명령어를 잘못 알았던게 원인이였다.