### PR TITLE
DAS-73 다이어리 일주일 기분 리스트 페이지 와이어프레임 적용

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import Statistics from "./pages/Statistics";
 import Map from "./pages/Map";
 import Support from "./pages/Support";
 import Settings from "./pages/Settings";
+import DiaryWeeklyList from "./pages/DiaryWeeklyList";
 
 function App() {
   return (
@@ -24,6 +25,7 @@ function App() {
             <Route path="feed" element={<Feed />} />
             <Route path="statistics" element={<Statistics />} />
           </Route>
+          <Route path="/weekly" element={<DiaryWeeklyList />} />
           <Route path="/" element={<SubPageLayout />}>
             <Route path="post" element={<DiaryPost />} />
             <Route path="map" element={<Map />} />

--- a/frontend/src/components/atoms/wrapper/Header/index.ts
+++ b/frontend/src/components/atoms/wrapper/Header/index.ts
@@ -16,4 +16,22 @@ export const Header = styled.header`
     line-height: 24px;
     margin-top: 4px;
   }
+
+  .back-button {
+    width: 24px;
+    height: 24px;
+    background: gray;
+  }
+
+  .title {
+    text-align: center;
+    width: 100%;
+    margin-left: -24px;
+
+    font-family: Pretendard;
+    font-weight: bold;
+    font-size: 16px;
+    line-height: 19px;
+    letter-spacing: -0.2px;
+  }
 `;

--- a/frontend/src/components/molecules/boxes/CalloutBox/index.tsx
+++ b/frontend/src/components/molecules/boxes/CalloutBox/index.tsx
@@ -1,0 +1,9 @@
+import * as React from "react";
+import { CalloutBoxWrap } from "./styles";
+
+function CalloutBox(props: { children: React.ReactNode }) {
+  const { children } = props;
+
+  return <CalloutBoxWrap>{children}</CalloutBoxWrap>;
+}
+export default CalloutBox;

--- a/frontend/src/components/molecules/boxes/CalloutBox/styles.ts
+++ b/frontend/src/components/molecules/boxes/CalloutBox/styles.ts
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+
+export const CalloutBoxWrap = styled.div`
+  padding: 6px 16px;
+  margin-bottom: 16px;
+
+  font-family: Pretendard;
+  font-size: 12px;
+  line-height: 140%;
+
+  background: #ffffff;
+  border-radius: 8px;
+  color: #1f1f1f;
+
+  filter: drop-shadow(0px 0px 1px rgba(0, 0, 0, 0.48))
+    drop-shadow(0px 0px 4px rgba(0, 0, 0, 0.12));
+`;

--- a/frontend/src/layouts/SubPageLayout/index.tsx
+++ b/frontend/src/layouts/SubPageLayout/index.tsx
@@ -1,17 +1,16 @@
 import { Header } from "../../components/atoms/wrapper/Header";
 import * as React from "react";
 import { Outlet } from "react-router";
-import { ButtonBox } from "../../layouts/MainLayout/styles";
+import { Link } from "react-router-dom";
 
 function SubPageLayout() {
   return (
     <>
       <Header>
-        <div>뒤로가기</div>
-        <ButtonBox>
-          <span>Search</span>
-          <span>hamberger</span>
-        </ButtonBox>
+        <Link to="/">
+          <div>&lt;</div>
+        </Link>
+        <span className="title"></span>
       </Header>
       <main>
         <Outlet />

--- a/frontend/src/pages/Diary/index.tsx
+++ b/frontend/src/pages/Diary/index.tsx
@@ -21,6 +21,7 @@ import type { DiaryTypes } from "recoil/Diary";
 import DailyCalendar from "../../components/molecules/calendars/DailyCalendar";
 import DiaryContentBox from "../../components/molecules/boxes/DiaryContentBox";
 import ToggleSwitchButton from "../../components/atoms/buttons/ToggleSwitchButton";
+import { Link } from "react-router-dom";
 
 interface Config {
   resources: {
@@ -33,9 +34,8 @@ function Diary() {
 
   const fetcher = useCallback(
     async (url: string) => {
-      console.log("실행?");
       const response = await axios.get<Config>(url);
-      console.log("data: ", response.data);
+      console.log("get response: ", response.data);
       setDiaries(response.data.resources.content);
 
       return response.data.resources.content;
@@ -58,15 +58,17 @@ function Diary() {
         </ShadowBox>
       </QuoteArticle>
       <WeeklyMoodArticle>
-        <ShadowBox align="center">
-          <div className="title">Weekly Mood</div>
-          <div className="date">2.07 - 2.13</div>
-          <div className="emotion-icon"></div>
-          <div className="suggestion">
-            You seem to have felt sad these days. Why don’t you share yout
-            story?
-          </div>
-        </ShadowBox>
+        <Link to="/weekly">
+          <ShadowBox align="center">
+            <div className="title">Weekly Mood</div>
+            <div className="date">2.07 - 2.13</div>
+            <div className="emotion-icon"></div>
+            <div className="suggestion">
+              You seem to have felt sad these days. Why don’t you share yout
+              story?
+            </div>
+          </ShadowBox>
+        </Link>
       </WeeklyMoodArticle>
       <DiaryArticle>
         <DailyCalendar>Jan 2022</DailyCalendar>

--- a/frontend/src/pages/DiaryWeeklyList/index.tsx
+++ b/frontend/src/pages/DiaryWeeklyList/index.tsx
@@ -1,0 +1,51 @@
+import { Header } from "../../components/atoms/wrapper/Header";
+import * as React from "react";
+import { Link } from "react-router-dom";
+import CalloutBox from "../../components/molecules/boxes/CalloutBox";
+import { Main } from "./styles";
+import DiaryContentBox from "../../components/molecules/boxes/DiaryContentBox";
+
+function DiaryWeeklyList() {
+  return (
+    <>
+      <Header>
+        <Link to="/">
+          <div className="back-button"></div>
+        </Link>
+        <div className="title">List of your weekly moods</div>
+      </Header>
+      <Main>
+        <CalloutBox>
+          These were analyzed using our model, based on what you’ve written
+          during last week. We show you in order of the most related diaries.
+        </CalloutBox>
+        <DiaryContentBox
+          key="1"
+          created_date=""
+          title="What can I do?"
+          content="So scary.. There’s nobody who will be on my side."
+        />
+        <DiaryContentBox
+          key="1"
+          created_date=""
+          title="What can I do?"
+          content="So scary.. There’s nobody who will be on my side."
+        />
+        <DiaryContentBox
+          key="1"
+          created_date=""
+          title="What can I do?"
+          content="So scary.. There’s nobody who will be on my side."
+        />
+        <DiaryContentBox
+          key="1"
+          created_date=""
+          title="What can I do?"
+          content="So scary.. There’s nobody who will be on my side."
+        />
+      </Main>
+    </>
+  );
+}
+
+export default DiaryWeeklyList;

--- a/frontend/src/pages/DiaryWeeklyList/styles.ts
+++ b/frontend/src/pages/DiaryWeeklyList/styles.ts
@@ -1,0 +1,5 @@
+import styled from "styled-components";
+
+export const Main = styled.main`
+  padding: 16px;
+`;

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -1,0 +1,15 @@
+const size = {
+  mobileS: "320px",
+  mobileM: "375px",
+  mobileL: "425px",
+  tablet: "768px",
+  laptop: "1024px",
+  laptopL: "1440px",
+  desktop: "2560px",
+};
+
+const theme = {
+  size,
+};
+
+export default theme;


### PR DESCRIPTION
## What is this PR? 🔍

일주일 단위로 다이어리 리스트 보여주는 페이지 와이어프레임 적용
- 다이어리 메인페이지 일주일 감정 분석 부분을 클릭하면 -> 위클리 무드 리스트로 이동
- `callout` 부분 컴포넌트 분리