### PR TITLE
DAS-114 텍스트 분석 결과로 나온 일주일 평균 기분을 다이어리 페이지에 아이콘과 멘트로 보여주기

### DIFF
--- a/frontend/src/components/molecules/boxes/WeeklyMoodBox/index.tsx
+++ b/frontend/src/components/molecules/boxes/WeeklyMoodBox/index.tsx
@@ -1,0 +1,74 @@
+import useDiaryActions from "hooks/useDiaryActions";
+import * as React from "react";
+import { Link } from "react-router-dom";
+import { useRecoilState } from "recoil";
+import { EmotionAverage, weeklyEmotionAverageAtom } from "recoil/Diary";
+import ShadowBox from "../ShadowBox";
+import {
+  Emotion,
+  emotionImages,
+} from "components/molecules/boxes/DiaryContentBox";
+
+import { WeeklyMoodWrap } from "./styles";
+
+function WeeklyMoodBox() {
+  const [weeklyEmotionAverage, setWeeklyEmotionAverage] =
+    useRecoilState<EmotionAverage>(weeklyEmotionAverageAtom);
+  const diaryActions = useDiaryActions();
+
+  return (
+    <WeeklyMoodWrap emotion={weeklyEmotionAverage.emotion.toLowerCase()}>
+      <Link to="/weekly">
+        <ShadowBox align="center">
+          <div className="date">
+            {weeklyEmotionAverage.startedDate.split("-")[1]}.
+            {weeklyEmotionAverage.startedDate.split("-")[2]}
+            {" - "}
+            {weeklyEmotionAverage.endedDate.split("-")[1]}.
+            {weeklyEmotionAverage.endedDate.split("-")[2]}
+          </div>
+          <div className="emotion-icon">
+            <img
+              src={
+                emotionImages[
+                  weeklyEmotionAverage.emotion.toLowerCase() as Emotion
+                ]
+              }
+            />
+          </div>
+          <div className="suggestion">
+            {weeklyEmotionAverage.emotion.toLowerCase() === "verysad" && (
+              <div>
+                Mommy, you look <b>Very Sad</b> recently.Why don’t you share
+                yours stories?
+              </div>
+            )}
+            {weeklyEmotionAverage.emotion.toLowerCase() === "sad" && (
+              <div>
+                Mommy, you look <b>Sad</b> recently. Why don’t you share your
+                stories?
+              </div>
+            )}
+            {weeklyEmotionAverage.emotion.toLowerCase() === "normal" && (
+              <div>
+                Mommy, you look <b>Normal</b> recently.
+              </div>
+            )}
+            {weeklyEmotionAverage.emotion.toLowerCase() === "happy" && (
+              <div>
+                Mommy, you look <b>Happy</b> recently.
+              </div>
+            )}
+            {weeklyEmotionAverage.emotion.toLowerCase() === "veryhappy" && (
+              <div>
+                Mommy, you look <b>Very Happy</b> recently.
+              </div>
+            )}
+          </div>
+        </ShadowBox>
+      </Link>
+    </WeeklyMoodWrap>
+  );
+}
+
+export default WeeklyMoodBox;

--- a/frontend/src/components/molecules/boxes/WeeklyMoodBox/styles.ts
+++ b/frontend/src/components/molecules/boxes/WeeklyMoodBox/styles.ts
@@ -1,0 +1,29 @@
+import styled from "styled-components";
+
+export const WeeklyMoodWrap = styled.article<{ emotion: string }>`
+  margin-bottom: 32px;
+  display: flex;
+  flex-direction: column;
+  font-family: "Roboto";
+
+  & > a > div {
+    background: ${(props) => props.theme.moodColor[props.emotion][30]};
+    padding: 12px 34px;
+  }
+
+  .date {
+    font-weight: 600;
+    line-height: 19px;
+  }
+  .emotion-icon > img {
+    width: 72px;
+    height: 72px;
+    margin: 6px 0;
+  }
+  .suggestion {
+    margin-top: 1px;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 150%;
+  }
+`;

--- a/frontend/src/hooks/useDiaryActions/index.ts
+++ b/frontend/src/hooks/useDiaryActions/index.ts
@@ -6,6 +6,7 @@ import { authAtom } from "recoil/Auth";
 import {
   diariesAtom,
   weeklyDiariesAtom,
+  weeklyEmotionAverageAtom,
 } from "recoil/Diary";
 import { DASONI_BACKEND_API } from "secret";
 
@@ -20,6 +21,7 @@ export interface DiaryPost {
 function useDiaryActions() {
   const setDiaries = useSetRecoilState(diariesAtom);
   const setWeeklyDiaries = useSetRecoilState(weeklyDiariesAtom);
+  const setWeeklyEmotionAverage = useSetRecoilState(weeklyEmotionAverageAtom);
   const auth = useRecoilValue(authAtom);
   let navigate = useNavigate();
 
@@ -41,6 +43,7 @@ function useDiaryActions() {
     await axios
       .get(url, config)
       .then((res) => {
+        setWeeklyEmotionAverage(res.data.emotionAverage);
         setDiaries(res.data.diaries);
       })
       .catch((error) => {
@@ -132,6 +135,7 @@ function useDiaryActions() {
 
   return {
     getDiaries,
+    getWeeklyDiaries,
     postDiary,
     deleteDiary,
   };

--- a/frontend/src/pages/Diary/index.tsx
+++ b/frontend/src/pages/Diary/index.tsx
@@ -20,16 +20,11 @@ import {
   QuoteArticle,
   Quote,
   RecentMoodLink,
-  WeeklyMoodArticle,
   Notification,
 } from "./styles";
 
 import arrow_right from "assets/icons/arrow-right.png";
-import very_sad from "assets/emotionIcons/verysad.svg";
-import sad from "assets/emotionIcons/sad.svg";
-import normal from "assets/emotionIcons/normal.svg";
-import happy from "assets/emotionIcons/happy.svg";
-import very_happy from "assets/emotionIcons/veryhappy.svg";
+import WeeklyMoodBox from "components/molecules/boxes/WeeklyMoodBox";
 
 function Diary() {
   const [diaries, setDiaries] = useRecoilState<DiaryTypes[]>(diariesAtom);
@@ -86,23 +81,7 @@ function Diary() {
             <img src={arrow_right} />
           </Link>
         </RecentMoodLink>
-
-        <WeeklyMoodArticle>
-          <Link to="/weekly">
-            <ShadowBox align="center">
-              <div className="date">
-                {month}.{day - 7} - {month}.{day}
-              </div>
-              <div className="emotion-icon">
-                <img src={very_sad} />
-              </div>
-              <div className="suggestion">
-                <div>Mommy, you look Very Sad recently.</div>
-                <div>Why don’t you share yours stories?</div>
-              </div>
-            </ShadowBox>
-          </Link>
-        </WeeklyMoodArticle>
+        <WeeklyMoodBox />
 
         <article>
           <DailyCalendar>Jan 2022</DailyCalendar>

--- a/frontend/src/pages/Diary/styles.ts
+++ b/frontend/src/pages/Diary/styles.ts
@@ -56,34 +56,6 @@ export const RecentMoodLink = styled.article`
   }
 `;
 
-export const WeeklyMoodArticle = styled.article`
-  margin-bottom: 32px;
-  display: flex;
-  flex-direction: column;
-  font-family: "Roboto";
-
-  & > a > div {
-    background: linear-gradient(0deg, #bce0fb, #bce0fb), #ffffff;
-    padding: 12px 34px;
-  }
-
-  .date {
-    font-weight: 600;
-    line-height: 19px;
-  }
-  .emotion-icon > img {
-    width: 72px;
-    height: 72px;
-    margin: 6px 0;
-  }
-  .suggestion {
-    margin-top: 1px;
-    font-weight: 400;
-    font-size: 14px;
-    line-height: 150%;
-  }
-`;
-
 export const Notification = styled.div`
   display: flex;
   flex-direction: row;

--- a/frontend/src/recoil/Diary/diary.ts
+++ b/frontend/src/recoil/Diary/diary.ts
@@ -1,6 +1,6 @@
 import { atom } from "recoil";
 
-import type { DiaryTypes } from "./types";
+import type { DiaryTypes, EmotionAverage } from "./types";
 
 export const diariesAtom = atom<DiaryTypes[]>({
   key: "diaries",
@@ -10,4 +10,13 @@ export const diariesAtom = atom<DiaryTypes[]>({
 export const weeklyDiariesAtom = atom<DiaryTypes[]>({
   key: "weeklyDiaries",
   default: [],
+});
+
+export const weeklyEmotionAverageAtom = atom<EmotionAverage>({
+  key: "weeklyEmotionAverage",
+  default: {
+    emotion: "Happy",
+    endedDate: "2022-03-26",
+    startedDate: "2022-04-01",
+  },
 });

--- a/frontend/src/recoil/Diary/types.ts
+++ b/frontend/src/recoil/Diary/types.ts
@@ -12,3 +12,9 @@ export interface Config {
     content: DiaryTypes[];
   };
 }
+
+export interface EmotionAverage {
+  emotion: string;
+  endedDate: string;
+  startedDate: string;
+}

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -9,11 +9,26 @@ const size = {
 };
 
 const moodColor = {
-  veryhappy: "#4cc968",
-  happy: "#b5e32f",
-  normal: "#ffbf41",
-  sad: "#6dcdf5",
-  verysad: "#2196f3",
+  veryhappy: {
+    100: "#4cc968",
+    30: "#c9efd2",
+  },
+  happy: {
+    100: "#b5e32f",
+    30: "#e9f7c1",
+  },
+  normal: {
+    100: "#ffbf41",
+    30: "#ffecc6",
+  },
+  sad: {
+    100: "#6dcdf5",
+    30: "#d3f0fc",
+  },
+  verysad: {
+    100: "#2196f3",
+    30: "#bce0fb",
+  },
 };
 
 const mainColor = "#FE6F5B";


### PR DESCRIPTION
## What is this PR? 🔍
텍스트 분석 결과로 나온 일주일 평균 기분을 다이어리 페이지에 아이콘과 멘트로 보여줬다.

- theme의 `moodColor`에 color level을 적용해서 감정별 배경색을 적용하기 쉽게 했다.
- `weeklyEmotionAverageAtom` atom 생성
- `getDiaries`에 `weeklyEmotionAverageAtom` 값을 넣는 부분을 추가
- `WeeklyMoodBox`를 컴포넌트로 분리하고, 일주일 평균 기분에 따른 아이콘과 날짜, 배경색상, 멘트를 넣어줬다